### PR TITLE
 connect, bind: don't try to redirect abstract sockets

### DIFF
--- a/preload.c
+++ b/preload.c
@@ -496,12 +496,12 @@ socket_action (int (*action) (int sockfd, const struct sockaddr *addr, socklen_t
     int result = 0;
     char *new_path = redirect_path (un_addr->sun_path);
 
-    if (strcmp (un_addr->sun_path, new_path) == 0) {
+    if (strncmp (un_addr->sun_path, new_path, sizeof (un_addr->sun_path)) == 0) {
         result = action (sockfd, addr, addrlen);
     } else {
         struct sockaddr_un new_addr = {0};
         new_addr.sun_family = AF_UNIX;
-        strcpy (new_addr.sun_path, new_path);
+        strncpy (new_addr.sun_path, new_path, sizeof (new_addr.sun_path));
         result = action (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
     }
 

--- a/preload.c
+++ b/preload.c
@@ -479,34 +479,33 @@ scandirat (int dirfd, const char *dirp, struct dirent ***namelist, int (*filter)
 }
 
 static int
-socket_action (int (*func) (int sockfd, const struct sockaddr *addr, socklen_t addrlen), int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+socket_action (int (*action) (int sockfd, const struct sockaddr *addr, socklen_t addrlen), int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-    int use_native = 1;
-    int result;
+    const struct sockaddr_un *un_addr = (const struct sockaddr_un *)addr;
 
-    if (addr->sa_family == AF_UNIX) {
-        const struct sockaddr_un *un_addr = (const struct sockaddr_un *)addr;
-
-        if (un_addr->sun_path[0] != '\0') {
-            char *new_path = redirect_path (un_addr->sun_path);
-
-            if (strcmp (un_addr->sun_path, new_path) != 0) {
-                struct sockaddr_un new_addr = {0};
-                new_addr.sun_family = AF_UNIX;
-                strcpy (new_addr.sun_path, new_path);
-
-                use_native = 0;
-                result = func (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
-            }
-
-            free (new_path);
-        }
+    if (addr->sa_family != AF_UNIX) {
+        // Non-unix sockets
+        return action (sockfd, addr, addrlen);
     }
 
-    if (use_native) {
-        result = func (sockfd, addr, addrlen);
+    if (un_addr->sun_path[0] == '\0') {
+        // Abstract sockets
+        return action (sockfd, addr, addrlen);
     }
 
+    int result = 0;
+    char *new_path = redirect_path (un_addr->sun_path);
+
+    if (strcmp (un_addr->sun_path, new_path) == 0) {
+        result = action (sockfd, addr, addrlen);
+    } else {
+        struct sockaddr_un new_addr = {0};
+        new_addr.sun_family = AF_UNIX;
+        strcpy (new_addr.sun_path, new_path);
+        result = action (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
+    }
+
+    free (new_path);
     return result;
 }
 

--- a/preload.c
+++ b/preload.c
@@ -478,14 +478,11 @@ scandirat (int dirfd, const char *dirp, struct dirent ***namelist, int (*filter)
     return ret;
 }
 
-int
-bind (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+static int
+socket_action (int (*func) (int sockfd, const struct sockaddr *addr, socklen_t addrlen), int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-    int (*_bind) (int sockfd, const struct sockaddr *addr, socklen_t addrlen);
     int use_native = 1;
     int result;
-
-    _bind = (int (*)(int sockfd, const struct sockaddr *addr, socklen_t addrlen)) dlsym (RTLD_NEXT, "bind");
 
     if (addr->sa_family == AF_UNIX) {
         const struct sockaddr_un *un_addr = (const struct sockaddr_un *)addr;
@@ -499,7 +496,7 @@ bind (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
                 strcpy (new_addr.sun_path, new_path);
 
                 use_native = 0;
-                result = _bind (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
+                result = func (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
             }
 
             free (new_path);
@@ -507,45 +504,28 @@ bind (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
     }
 
     if (use_native) {
-        result = _bind (sockfd, addr, addrlen);
+        result = func (sockfd, addr, addrlen);
     }
 
     return result;
 }
 
 int
+bind (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    int (*_bind) (int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+
+    _bind = (int (*)(int sockfd, const struct sockaddr *addr, socklen_t addrlen)) dlsym (RTLD_NEXT, "bind");
+    return socket_action (_bind, sockfd, addr, addrlen);
+}
+
+int
 connect (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
     int (*_connect) (int sockfd, const struct sockaddr *addr, socklen_t addrlen);
-    int use_native = 1;
-    int result;
 
     _connect = (int (*)(int sockfd, const struct sockaddr *addr, socklen_t addrlen)) dlsym (RTLD_NEXT, "connect");
-
-    if (addr->sa_family == AF_UNIX) {
-        const struct sockaddr_un *un_addr = (const struct sockaddr_un *)addr;
-
-        if (un_addr->sun_path[0] != '\0') {
-            char *new_path = redirect_path (un_addr->sun_path);
-
-            if (strcmp (un_addr->sun_path, new_path) != 0) {
-                struct sockaddr_un new_addr = {0};
-                new_addr.sun_family = AF_UNIX;
-                strcpy (new_addr.sun_path, new_path);
-
-                use_native = 0;
-                result = _connect (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
-            }
-
-            free (new_path);
-        }
-    }
-
-    if (use_native) {
-        result = _connect (sockfd, addr, addrlen);
-    }
-
-    return result;
+    return socket_action (_connect, sockfd, addr, addrlen);
 }
 
 void *

--- a/preload.c
+++ b/preload.c
@@ -496,13 +496,14 @@ socket_action (int (*action) (int sockfd, const struct sockaddr *addr, socklen_t
     int result = 0;
     char *new_path = redirect_path (un_addr->sun_path);
 
-    if (strncmp (un_addr->sun_path, new_path, sizeof (un_addr->sun_path)) == 0) {
+    if (strncmp (un_addr->sun_path, new_path, PATH_MAX) == 0) {
         result = action (sockfd, addr, addrlen);
     } else {
         struct sockaddr_un new_addr = {0};
         new_addr.sun_family = AF_UNIX;
-        strncpy (new_addr.sun_path, new_path, sizeof (new_addr.sun_path));
-        result = action (sockfd, (const struct sockaddr *)&new_addr, sizeof(new_addr));
+        new_addr.sun_path[0] = '\0';
+        strncat (new_addr.sun_path, new_path, PATH_MAX - 1);
+        result = action (sockfd, (const struct sockaddr *) &new_addr, sizeof (new_addr));
     }
 
     free (new_path);


### PR DESCRIPTION
If sun_path[0] == '\0', then we're handling an abstract
socket and its path has not a direct connection with
filesystem, thus we should not try to redirect it.

Without this it's impossible to use preload in X apps as they
won't be able to connect to `/tmp/.X11-unix/X0` abstract socket