### PR TITLE
preload: handle strings reducing duplicated computations

### DIFF
--- a/preload.c
+++ b/preload.c
@@ -190,7 +190,6 @@ redirect_path_full (const char *pathname, int check_parent, int only_if_absolute
         return redirected_pathname;
     }
 
-
     if (preload_dir[preload_dir_len - 1] == '/') {
         chop = 1;
     }

--- a/preload.c
+++ b/preload.c
@@ -88,13 +88,13 @@ void constructor()
     // Pull out each absolute-pathed libsnapcraft-preload.so we find.  Better to
     // accidentally include some other libsnapcraft-preload than not propagate
     // ourselves.
-    libnamelen = strlen (SNAPCRAFT_LIBNAME);
+    libnamelen = sizeof (SNAPCRAFT_LIBNAME) - 1;
     for (p = strtok_r (ld_preload_copy, " :", &savedptr);
          p;
          p = strtok_r (NULL, " :", &savedptr)) {
         size_t plen = strlen (p);
-        if (plen > libnamelen && p[0] == '/' && strcmp (p + plen - libnamelen - 1, "/" SNAPCRAFT_LIBNAME) == 0) {
-            num_saved_ld_preloads++;
+        if (plen > libnamelen && p[0] == '/' && strncmp (p + plen - libnamelen - 1, "/" SNAPCRAFT_LIBNAME, libnamelen + 1) == 0) {
+            ++num_saved_ld_preloads;
             saved_ld_preloads = realloc (saved_ld_preloads, (num_saved_ld_preloads + 1) * sizeof (char *));
             saved_ld_preloads[num_saved_ld_preloads - 1] = strdup (p);
             saved_ld_preloads[num_saved_ld_preloads] = NULL;

--- a/preload.c
+++ b/preload.c
@@ -147,8 +147,6 @@ redirect_path_full (const char *pathname, int check_parent, int only_if_absolute
 {
     int (*_access) (const char *pathname, int mode);
     char *redirected_pathname;
-    char *preload_dir;
-    size_t preload_dir_len;
     int ret;
     int chop = 0;
     char *slash = 0;
@@ -157,8 +155,8 @@ redirect_path_full (const char *pathname, int check_parent, int only_if_absolute
         return NULL;
     }
 
-    preload_dir = saved_snapcraft_preload;
-    preload_dir_len = saved_snapcraft_preload_len;
+    const char *preload_dir = saved_snapcraft_preload;
+    const size_t preload_dir_len = saved_snapcraft_preload_len;
 
     if (preload_dir == NULL) {
         return strdup (pathname);

--- a/preload.c
+++ b/preload.c
@@ -88,12 +88,12 @@ void constructor()
     // Pull out each absolute-pathed libsnapcraft-preload.so we find.  Better to
     // accidentally include some other libsnapcraft-preload than not propagate
     // ourselves.
-    libnamelen = strlen(SNAPCRAFT_LIBNAME);
+    libnamelen = strlen (SNAPCRAFT_LIBNAME);
     for (p = strtok_r (ld_preload_copy, " :", &savedptr);
          p;
          p = strtok_r (NULL, " :", &savedptr)) {
         size_t plen = strlen (p);
-        if (plen > libnamelen && p[0] == '/' && strcmp (p + strlen (p) - strlen (SNAPCRAFT_LIBNAME) - 1, "/" SNAPCRAFT_LIBNAME) == 0) {
+        if (plen > libnamelen && p[0] == '/' && strcmp (p + plen - libnamelen - 1, "/" SNAPCRAFT_LIBNAME) == 0) {
             num_saved_ld_preloads++;
             saved_ld_preloads = realloc (saved_ld_preloads, (num_saved_ld_preloads + 1) * sizeof (char *));
             saved_ld_preloads[num_saved_ld_preloads - 1] = strdup (p);

--- a/preload.c
+++ b/preload.c
@@ -37,9 +37,9 @@
 #define SNAPCRAFT_LIBNAME "snapcraft-preload.so"
 #endif
 
-#define STATIC_STRLEN(s) (sizeof (s) - 1)
+#define LITERAL_STRLEN(s) (sizeof (s) - 1)
 #define LD_PRELOAD "LD_PRELOAD"
-#define LD_PRELOAD_LEN STATIC_STRLEN (LD_PRELOAD)
+#define LD_PRELOAD_LEN LITERAL_STRLEN (LD_PRELOAD)
 #define SNAPCRAFT_PRELOAD "SNAPCRAFT_PRELOAD"
 
 static char **saved_ld_preloads = NULL;
@@ -105,7 +105,7 @@ void constructor()
     // Pull out each absolute-pathed libsnapcraft-preload.so we find.  Better to
     // accidentally include some other libsnapcraft-preload than not propagate
     // ourselves.
-    libnamelen = STATIC_STRLEN (SNAPCRAFT_LIBNAME);
+    libnamelen = LITERAL_STRLEN (SNAPCRAFT_LIBNAME);
     for (p = strtok_r (ld_preload_copy, " :", &savedptr);
          p;
          p = strtok_r (NULL, " :", &savedptr)) {
@@ -636,8 +636,8 @@ execve_copy_envp (char *const envp[])
     }
 
     if (saved_snapcraft_preload) {
-        snapcraft_preload = malloc (saved_snapcraft_preload_len + STATIC_STRLEN (SNAPCRAFT_PRELOAD) + 2);
-        strncpy (snapcraft_preload, SNAPCRAFT_PRELOAD "=", STATIC_STRLEN (SNAPCRAFT_PRELOAD) + 1);
+        snapcraft_preload = malloc (saved_snapcraft_preload_len + LITERAL_STRLEN (SNAPCRAFT_PRELOAD) + 2);
+        strncpy (snapcraft_preload, SNAPCRAFT_PRELOAD "=", LITERAL_STRLEN (SNAPCRAFT_PRELOAD) + 1);
         strncat (snapcraft_preload, saved_snapcraft_preload, saved_snapcraft_preload_len);
         new_envp[i++] = snapcraft_preload;
     }


### PR DESCRIPTION
Keep strings lengths cached and use them instead of repeatedly using `strlen`.