### PR TITLE
snapcraft.yaml: add snapcraft-preload part and keep preload as backup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,4 +31,3 @@ endif()
 
 install(TARGETS snapcraft-preload LIBRARY DESTINATION lib)
 install(PROGRAMS snapcraft-preload DESTINATION bin)
-install(PROGRAMS preload DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Add this as a part to your `snapcraft.yaml`:
 
 ```yaml
 parts:
-    preload:
+    snapcraft-preload:
         source: https://github.com/sergiusens/snapcraft-preload.git
         plugin: cmake
 ```

--- a/preload
+++ b/preload
@@ -1,1 +1,0 @@
-snapcraft-preload

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,15 +4,23 @@ summary: Preloader utility for snaps
 description: |
     Tired of dealing with hardcoded paths and code just being antiquated? This is the part for you.
     While still in experimental stages it is useful already. All you need to do is add this part
-    to your snapcraft project and prepend `command` entries in `apps` with `preload`.
+    to your snapcraft project and prepend `command` entries in `apps` with `snapcraft-preload`.
 
 grade: devel
 confinement: devmode
 
 parts:
-    preload:
+    snapcraft-preload:
         source: .
         plugin: cmake
         build-packages:
             - gcc-multilib
             - g++-multilib
+
+    # We keep the 'preload' part to be backward compatible
+    preload:
+      plugin: nil
+      install: |
+        mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+        ln -sv snapcraft-preload $SNAPCRAFT_PART_INSTALL/bin/preload
+      after: [snapcraft-preload]


### PR DESCRIPTION
Add the 'preload' binary only if the "preload" leagacy part is being used.