### PR TITLE
Update the parts section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Add this as a part to your `snapcraft.yaml`:
 ```yaml
 parts:
     snapcraft-preload:
-        source: .
+        source: https://github.com/sergiusens/snapcraft-preload.git
         plugin: cmake
         build-packages:
             - gcc-multilib

--- a/README.md
+++ b/README.md
@@ -5,8 +5,19 @@ Add this as a part to your `snapcraft.yaml`:
 ```yaml
 parts:
     snapcraft-preload:
-        source: https://github.com/sergiusens/snapcraft-preload.git
+        source: .
         plugin: cmake
+        build-packages:
+            - gcc-multilib
+            - g++-multilib
+
+    # We keep the 'preload' part to be backward compatible
+    preload:
+      plugin: nil
+      install: |
+        mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+        ln -sv snapcraft-preload $SNAPCRAFT_PART_INSTALL/bin/preload
+after: [snapcraft-preload]
 ```
 
 And precede your `apps` entry like this:


### PR DESCRIPTION
Please add all the entries required as said in `snapcraft.yaml`. For ex- missing the build package `g++-multilib` will cause this issue. Please make this clear so that people can get their snaps working again. Majority will read the instruction in `README` rather than in `snapcraft.yaml`.