### PR TITLE
ensure g++/gcc-multilib only required for amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ parts:
         source: https://github.com/sergiusens/snapcraft-preload.git
         plugin: cmake
         build-packages:
-          - gcc-multilib
-          - g++-multilib
+          - on amd64:
+            - gcc-multilib
+            - g++-multilib
 ```
 
 And precede your `apps` entry like this:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,8 +14,9 @@ parts:
         source: .
         plugin: cmake
         build-packages:
-            - gcc-multilib
-            - g++-multilib
+            - on amd64:
+                - gcc-multilib
+                - g++-multilib
 
     # We keep the 'preload' part to be backward compatible
     preload:


### PR DESCRIPTION
This allows the build to work on ppc64el and arm64, which don't have the multilib variants of gcc/g++. Also the only platform we use the multilib variants is amd64.