### PR TITLE
Allow chaining with other things that set LD_PRELOAD

### DIFF
--- a/snapcraft-preload.in
+++ b/snapcraft-preload.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 export SNAPCRAFT_PRELOAD=$SNAP
-export LD_PRELOAD="$SNAP/@LIBPATH@/@LIBNAME@.so"
+export LD_PRELOAD="$SNAP/@LIBPATH@/@LIBNAME@.so:$LD_PRELOAD"
 
 exec "$@"


### PR DESCRIPTION
`LD_PRELOAD` libraries are loaded in reverse order, so the fist lib takes precedence. The trailing `:` does not cause a problem.