### PR TITLE
Add PREFIX to the YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ parts:
     snapcraft-preload:
         source: https://github.com/sergiusens/snapcraft-preload.git
         plugin: cmake
+        cmake-parameters:
+          - -DCMAKE_INSTALL_PREFIX=/
         build-packages:
           - on amd64:
             - gcc-multilib


### PR DESCRIPTION
In order to this to work, it is mandatory that the executable is
installed in /bin, and the library in /lib (relative to the SNAP,
of course). For this, it is necessary to add a 'cmake-parameters'
to the YAML code.

This MR modifies the README.md to include that.